### PR TITLE
Moved git tutorial from tutorials to books

### DIFF
--- a/books/free-programming-books-en.md
+++ b/books/free-programming-books-en.md
@@ -8,3 +8,4 @@
 * [English, By Programming Language](free-programming-books-langs.md)
   [English, By Subject](free-programming-books-subjects.md)
   (The list of books in English is here for historical reasons.)
+* [Git-Tutorial For-Beginners](https://product.hubspot.com/blog/git-and-github-tutorial-for-beginners) - HubSpot Product Team 


### PR DESCRIPTION
## What does this PR do?
Add resource(s) | Remove resource(s) | Add info | Improve repo
Moved [Git-Tutorial For-Beginners](https://product.hubspot.com/blog/git-and-github-tutorial-for-beginners) - HubSpot Product Team from tutorials to books
## For resources
### Description
Moved the course as advised in request #6135 Thanks :)
### Why is this valuable (or not)?
It is a blog post, but this covers a topic
### How do we know it's really free?
It has been visited and tested
### For book lists, is it a book? For course lists, is it a course? etc.
Book
## Checklist:
- [ ] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/master/CONTRIBUTING.md)
- [ ] Search for duplicates.
- [ ] Include author(s) and platform where appropriate.
- [ ] Put lists in alphabetical order, correct spacing.
- [ ] Add needed indications (PDF, access notes, under construction)

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
