### PR TITLE
Removed git tutorial from tutorials

### DIFF
--- a/more/free-programming-interactive-tutorials-en.md
+++ b/more/free-programming-interactive-tutorials-en.md
@@ -128,7 +128,6 @@
 * [git-game](https://github.com/git-game/git-game)
 * [git-game-v2](https://github.com/git-game/git-game-v2)
 * [Git Tutorial](https://www.w3schools.com/git/) - W3Schools
-* [Git-Tutorial For-Beginners](https://product.hubspot.com/blog/git-and-github-tutorial-for-beginners)
 * [Githug](https://github.com/Gazler/githug) (Tutorial in shell)
 * [Learn Git Branching](https://learngitbranching.js.org)
 * [Learn Git with Bitbucket Cloud](https://www.atlassian.com/git/tutorials/learn-git-with-bitbucket-cloud)


### PR DESCRIPTION
## What does this PR do?
Add resource(s) | Remove resource(s) | Add info | Improve repo
Removed Git tutorial from tutorials
## For resources
### Description
Moved Git tutorial from tutorials to books
### Why is this valuable (or not)?
It is a blog post but it covers the topic.
### How do we know it's free?
I have visited and tested
### For book lists, is it a book? For course lists, is it a course? etc.
Tutorial
## Checklist:
- [x] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/master/CONTRIBUTING.md)
- [x] Search for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction)

## Follow-up

- Check the status of GitHub Actions and resolve any reported warnings!
